### PR TITLE
Update Python workflow based on DevDiv feedback

### DIFF
--- a/AppService/linux/python-webapp-on-azure.yml
+++ b/AppService/linux/python-webapp-on-azure.yml
@@ -14,17 +14,6 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
-
-    - name: Set up Python version
-      uses: actions/setup-python@v1
-      with:
-        python-version: '${python-version}'
-    
-    - name: Build using AppService-Build
-      uses: azure/appservice-build@v2
-      with:
-        platform: python
-        platform-version: '${python-version}'
     
     - name: 'Deploy to Azure Web App'
     - uses: azure/webapps-deploy@v2


### PR DESCRIPTION
Summary

- Oryx build action does not *currently* cover all Python scenarios well enough
- This change requires that the Portal sets `SCM_DO_BUILD_DURING_DEPLOYMENT` to `true` so the build can be delegated back to Kudu